### PR TITLE
Enabling workloadidentity

### DIFF
--- a/zero-sum-main/gke.tf
+++ b/zero-sum-main/gke.tf
@@ -8,6 +8,10 @@ resource "google_container_cluster" "primary" {
 
   remove_default_node_pool = true
   initial_node_count       = 1
+  
+  workload_identity_config {
+    workload_pool = "${local.project}.svc.id.goog"
+  }
 
   network    = google_compute_network.main_vpc_network.name
   subnetwork = google_compute_subnetwork.main_subnet.name
@@ -18,7 +22,7 @@ resource "google_container_node_pool" "primary_nodes" {
   location   = local.region
   cluster    = google_container_cluster.primary.name
   node_count = var.gke_number_nodes
-
+  
   node_config {
     // I'll fix the scopes later
     oauth_scopes = [


### PR DESCRIPTION
Enabling WorkloadIdentifty to make it easier for GKE services to access outside resources

https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity