### PR TITLE
Redmine

### DIFF
--- a/zero-sum-main/dns.tf
+++ b/zero-sum-main/dns.tf
@@ -39,6 +39,19 @@ resource "google_dns_record_set" "jenkins_cname_record" {
   ]
 }
 
+resource "google_dns_record_set" "jenkins_cname_record" {
+  name         = "redmine.${google_dns_managed_zone.zero_sum.dns_name}"
+  type         = "CNAME"
+  ttl          = 300
+  project      = local.project
+  managed_zone = google_dns_managed_zone.zero_sum.name
+  rrdatas      = [google_dns_record_set.nginx_ingress.name]
+
+  depends_on = [
+    google_dns_managed_zone.zero_sum
+  ]
+}
+
 resource "google_dns_record_set" "nginx_ingress" {
   name         = "nginx-ingress.${google_dns_managed_zone.zero_sum.dns_name}"
   project      = local.project

--- a/zero-sum-main/redmine.tf
+++ b/zero-sum-main/redmine.tf
@@ -1,0 +1,34 @@
+﻿resource "google_service_account" "redmine" {
+  project      = local.project
+  account_id   = "redmine"
+  display_name = "redmine"
+  description  = "redmine"
+}
+
+resource "google_project_iam_member" "redmine_cloudsql" {
+  role   = "roles/cloudsql.client"
+  member = "serviceAccount:${google_service_account.redmine.email}"
+}
+
+resource "google_sql_database_instance" "redmine-db" {
+  project          = local.project
+  name             = "redmine-db"
+  database_version = "MYSQL_8_0"
+  region           = local.region
+
+  settings {
+    tier = "db-f1-micro"
+
+    backup_configuration {
+      enabled = true
+    }
+  }
+}
+
+resource "google_sql_database" "unity-polr-mysql-db" {
+  project = local.project
+  name     = "bitnami_redmine"
+  instance = google_sql_database_instance.redmine-db.name
+  charset  = "UTF8"
+}
+

--- a/zero-sum-main/redmine.tf
+++ b/zero-sum-main/redmine.tf
@@ -32,3 +32,8 @@ resource "google_sql_database" "unity-polr-mysql-db" {
   charset  = "UTF8"
 }
 
+resource "google_service_account_iam_member" "redmine_workload_identity" {
+  service_account_id = google_service_account.redmine.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${local.project}.svc.id.goog[redmine/redmine]"
+}


### PR DESCRIPTION
PR Adds a small Redmine DB which the redmine pod will access with a cloudsql proxy initcontainer
 